### PR TITLE
Render memory age in the system prompt

### DIFF
--- a/src/ai/agent.test.ts
+++ b/src/ai/agent.test.ts
@@ -96,6 +96,28 @@ describe('AgentOrchestrator.handleMention', () => {
     expect(promptText).not.toContain('prefer emojis near the top');
   });
 
+  it('annotates injected memory lines with their relative age and warns about stale current-state claims', async () => {
+    // Default fake author display name is 'Test User', the key buildDeveloperPrompt fetches by.
+    await getMemoryStore().save({ category: 'fact', subject: 'Test User', content: 'works as a plumber' });
+
+    const provider = new FakeProvider([textResponse('Hi')]);
+    const orchestrator = makeOrchestrator(provider);
+    const fake = createFakeMessage({ content: 'hello' });
+
+    await orchestrator.handleMention(fake.message);
+
+    const developerEntry = provider.calls[0].messages.find(
+      (e): e is Extract<ConversationEntry, { kind: 'message' }> => e.kind === 'message' && e.role === 'developer',
+    );
+    expect(developerEntry).toBeDefined();
+    const promptText = developerEntry!.content.map((p) => (p.type === 'text' ? p.text : '')).join('\n');
+
+    // The just-saved memory renders with a 'today' age annotation appended.
+    expect(promptText).toContain('- works as a plumber (today)');
+    // The guidance sentence teaching the model to distrust stale current-state claims is present.
+    expect(promptText).toContain('how long ago it was last confirmed');
+  });
+
   it('executes a single tool round then replies', async () => {
     const provider = new FakeProvider([
       toolCallResponse([{ id: 't1', name: 'echo_tool', arguments: {} }]),

--- a/src/ai/agent.ts
+++ b/src/ai/agent.ts
@@ -16,7 +16,7 @@ import type {
   ProviderToolCall,
   ToolDefinition,
 } from './types';
-import { formatTimestampET } from './utils';
+import { formatRelativeAge, formatTimestampET } from './utils';
 
 const CONVERSATION_TIMEOUT = Number(process.env.CONVERSATION_TIMEOUT_MS) || 15 * 60 * 1000; // 15 minutes
 const MAX_TOOL_ROUNDS = Number(process.env.MAX_TOOL_ROUNDS) || 10;
@@ -385,17 +385,17 @@ export class AgentOrchestrator {
 
     const personalitySection =
       personalityMemories.length > 0
-        ? `\nWhat you've learned about this server's culture and vibe:\n${personalityMemories.map((m) => `- ${m.content}`).join('\n')}\n`
+        ? `\nWhat you've learned about this server's culture and vibe:\n${personalityMemories.map((m) => `- ${m.content} (${formatRelativeAge(m.updated_at)})`).join('\n')}\n`
         : '';
 
     const userSection =
       userSpecificMemories.length > 0
-        ? `\nWhat you know about the person talking to you right now (${currentUserDisplayName}):\n${userSpecificMemories.map((m) => `- ${m.content}`).join('\n')}\n`
+        ? `\nWhat you know about the person talking to you right now (${currentUserDisplayName}):\n${userSpecificMemories.map((m) => `- ${m.content} (${formatRelativeAge(m.updated_at)})`).join('\n')}\n`
         : '';
 
     const contextualSection =
       contextualMemories.length > 0
-        ? `\nRelevant to this conversation:\n${contextualMemories.map((m) => `- [${m.category}] ${m.subject}: ${m.content}`).join('\n')}\n`
+        ? `\nRelevant to this conversation:\n${contextualMemories.map((m) => `- [${m.category}] ${m.subject}: ${m.content} (${formatRelativeAge(m.updated_at)})`).join('\n')}\n`
         : '';
 
     return `You are ${botName}, a bot in a private, adults-only Discord server.
@@ -416,7 +416,7 @@ How you behave:
 
 You can search the web natively. Use it SPARINGLY — only when you genuinely need current, real-time information you couldn't possibly know (live scores, recent news, release dates, etc). Don't search for things you already know. Don't follow links people share.
 ${identitiesSection}${emojisSection}${personalitySection}${userSection}${contextualSection}
-These memories are background knowledge — things you know from hanging out in this server. Do NOT force references to inside jokes, show off what you know, or try to reference multiple memories in one response. Let things come up naturally, the way you'd reference a friend's hobby only when it's actually relevant to the conversation. If nothing from your memories is relevant to what's being discussed, just don't mention them.
+These memories are background knowledge — things you know from hanging out in this server. Do NOT force references to inside jokes, show off what you know, or try to reference multiple memories in one response. Let things come up naturally, the way you'd reference a friend's hobby only when it's actually relevant to the conversation. If nothing from your memories is relevant to what's being discussed, just don't mention them. Each memory is tagged with how long ago it was last confirmed; treat months-old current-state claims — what someone "still" does, owns, or plays — as possibly outdated, so hedge or ask instead of asserting them as current fact.
 
 MEMORY: You have a long-term memory system. Use the remember_fact tool when something genuinely important comes up — real names, jobs, major life events, strong preferences, or things someone would expect you to remember next time. Do NOT save every little thing; skip small talk, throwaway opinions, and mundane details. Think of what you'd actually remember about a friend after a night out — the big stuff, not every sentence. If someone corrects a fact you know, save the updated version.
 

--- a/src/ai/utils.test.ts
+++ b/src/ai/utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { formatRelativeAge } from './utils';
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+// A fixed UTC instant; building both `now` and the timestamps from UTC keeps these assertions
+// identical on any host timezone (the function itself forces UTC by appending 'Z').
+const NOW = new Date(Date.UTC(2026, 5, 12, 12, 0, 0));
+
+// Renders a Date back into SQLite's 'YYYY-MM-DD HH:MM:SS' UTC shape (no zone suffix).
+function sqliteUtc(date: Date): string {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+function ago(ms: number): string {
+  return sqliteUtc(new Date(NOW.getTime() - ms));
+}
+
+describe('formatRelativeAge', () => {
+  it('returns "today" for anything under 24h', () => {
+    expect(formatRelativeAge(ago(0), NOW)).toBe('today');
+    expect(formatRelativeAge(ago(23 * HOUR_MS), NOW)).toBe('today');
+  });
+
+  it('uses days from 24h up to 14 days', () => {
+    expect(formatRelativeAge(ago(DAY_MS), NOW)).toBe('1d ago');
+    expect(formatRelativeAge(ago(13 * DAY_MS + 23 * HOUR_MS), NOW)).toBe('13d ago');
+  });
+
+  it('uses weeks from 14 days up to 8 weeks', () => {
+    expect(formatRelativeAge(ago(14 * DAY_MS), NOW)).toBe('2w ago');
+    expect(formatRelativeAge(ago(55 * DAY_MS), NOW)).toBe('7w ago');
+  });
+
+  it('uses months from 8 weeks onward', () => {
+    expect(formatRelativeAge(ago(56 * DAY_MS), NOW)).toBe('1mo ago');
+    expect(formatRelativeAge(ago(90 * DAY_MS), NOW)).toBe('3mo ago');
+  });
+
+  it('clamps future timestamps to "today"', () => {
+    expect(formatRelativeAge(ago(-DAY_MS), NOW)).toBe('today');
+  });
+
+  it('parses the timestamp as UTC, not host-local time', () => {
+    // Exactly 60 days before NOW in UTC. Because the function forces UTC ('Z') and NOW is built from
+    // Date.UTC, this lands at "2mo ago" on every host timezone — a local-time parse would skew it.
+    expect(formatRelativeAge('2026-04-13 12:00:00', NOW)).toBe('2mo ago');
+  });
+
+  it('returns "" for missing or garbage input', () => {
+    expect(formatRelativeAge('', NOW)).toBe('');
+    expect(formatRelativeAge('not a date', NOW)).toBe('');
+    expect(formatRelativeAge('2026-13-99 99:99:99', NOW)).toBe('');
+  });
+
+  it('defaults `now` to the current time', () => {
+    expect(formatRelativeAge(sqliteUtc(new Date(Date.now() - 5_000)))).toBe('today');
+  });
+});

--- a/src/ai/utils.ts
+++ b/src/ai/utils.ts
@@ -11,3 +11,25 @@ const ET_DATETIME_FORMAT = new Intl.DateTimeFormat('sv-SE', {
 export function formatTimestampET(date: Date): string {
   return ET_DATETIME_FORMAT.format(date);
 }
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Renders a SQLite `datetime('now')` timestamp ('YYYY-MM-DD HH:MM:SS', UTC, no zone) as a terse
+ * relative age for prompt injection. The space→'T' + 'Z' rewrite makes the UTC explicit; without it
+ * `new Date()` reads the string as local time and skews on any non-UTC host. Garbage/missing input
+ * yields '' so prompt building never throws.
+ */
+export function formatRelativeAge(sqliteUtcTimestamp: string, now: Date = new Date()): string {
+  if (!sqliteUtcTimestamp) return '';
+
+  const parsed = new Date(`${sqliteUtcTimestamp.replace(' ', 'T')}Z`);
+  const elapsedMs = now.getTime() - parsed.getTime();
+  if (!Number.isFinite(elapsedMs)) return '';
+
+  const days = Math.max(0, elapsedMs) / DAY_MS;
+  if (days < 1) return 'today';
+  if (days < 14) return `${Math.floor(days)}d ago`;
+  if (days < 56) return `${Math.floor(days / 7)}w ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+}


### PR DESCRIPTION
Injected memories were rendered as bare content with no date, so the model asserted months-old current-state facts in eternal present tense. Append a terse relative age (today / Nd / Nw / Nmo ago) to every injected memory line using updated_at (dedup-merge re-observations bump it, so re-confirmed facts read as fresh), and tell the model in the guidance paragraph to hedge on months-old current-state claims instead of asserting them.

New formatRelativeAge() helper parses SQLite's space-separated UTC timestamps explicitly as UTC and returns '' on garbage so prompt building never throws.