### PR TITLE
Resolve @-mentions in memory retrieval instead of stripping them

### DIFF
--- a/src/ai/agent.test.ts
+++ b/src/ai/agent.test.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFakeMessage } from '../test-support/fakeDiscord';
+import { FakeEmbeddingProvider } from '../test-support/fakeEmbeddings';
 import { FakeProvider, errorStep, textResponse, toolCallResponse } from '../test-support/fakeProvider';
 import { AgentOrchestrator } from './agent';
 import { loadErrorCapture } from './debugCapture';
@@ -310,5 +311,179 @@ describe('AgentOrchestrator.handleMention', () => {
 
     expect(fake1.recorders.messagesFetch.calls).toHaveLength(1);
     expect(fake2.recorders.messagesFetch.calls).toHaveLength(1);
+  });
+});
+
+function developerPromptText(provider: FakeProvider): string {
+  const developerEntry = provider.calls[0].messages.find(
+    (e): e is Extract<ConversationEntry, { kind: 'message' }> => e.kind === 'message' && e.role === 'developer',
+  );
+  return developerEntry?.content.map((p) => (p.type === 'text' ? p.text : '')).join('\n') ?? '';
+}
+
+function lastUserText(provider: FakeProvider): string {
+  const userEntries = provider.calls[0].messages.filter(
+    (e): e is Extract<ConversationEntry, { kind: 'message' }> => e.kind === 'message' && e.role === 'user',
+  );
+  const last = userEntries.at(-1);
+  return last?.content.map((p) => (p.type === 'text' ? p.text : '')).join('\n') ?? '';
+}
+
+function lastQuery(embeddings: FakeEmbeddingProvider): string {
+  const queryCalls = embeddings.calls.filter((c) => c.kind === 'query');
+  expect(queryCalls.length).toBeGreaterThan(0);
+  return queryCalls.at(-1)!.texts[0];
+}
+
+// Discord ids are numeric snowflakes; the mention regex matches `\d+` only (as the original strip
+// regex did), so tests must use numeric ids.
+const BOT_ID = '900000000000000001';
+const WHEEZER_ID = '137738554762592257';
+const SPEAKER_ID = '111111111111111111';
+const STRANGER_ID = '222222222222222222';
+
+describe('AgentOrchestrator @-mention resolution', () => {
+  it('resolves a mentioned user into the semantic-search query instead of stripping them', async () => {
+    const embeddings = new FakeEmbeddingProvider();
+    setMemoryStoreForTesting(new MemoryStore(':memory:', { embeddings }));
+
+    const provider = new FakeProvider([textResponse('Hi')]);
+    const orchestrator = makeOrchestrator(provider);
+    const fake = createFakeMessage({
+      content: `whats up with <@${WHEEZER_ID}>`,
+      botUserId: BOT_ID,
+      mentionedUsers: [{ id: WHEEZER_ID, displayName: 'Wheezer' }],
+    });
+
+    await orchestrator.handleMention(fake.message);
+
+    const query = lastQuery(embeddings);
+    expect(query).toContain('@Wheezer');
+    expect(query).not.toContain('<@');
+  });
+
+  it('falls back to the identities table when a mention has no live display data', async () => {
+    const embeddings = new FakeEmbeddingProvider();
+    const store = new MemoryStore(':memory:', { embeddings });
+    store.upsertIdentity(WHEEZER_ID, 'Wheezer');
+    setMemoryStoreForTesting(store);
+
+    const provider = new FakeProvider([textResponse('Hi')]);
+    const orchestrator = makeOrchestrator(provider);
+    // mentionedUserIds populates mentions.users with a bare entry (no display name), forcing the
+    // identities-table fallback.
+    const fake = createFakeMessage({
+      content: `hows <@${WHEEZER_ID}> doing`,
+      botUserId: BOT_ID,
+      mentionedUserIds: [WHEEZER_ID],
+    });
+
+    await orchestrator.handleMention(fake.message);
+
+    expect(lastQuery(embeddings)).toContain('@Wheezer');
+  });
+
+  it("strips the bot's own trigger mention from the query", async () => {
+    const embeddings = new FakeEmbeddingProvider();
+    setMemoryStoreForTesting(new MemoryStore(':memory:', { embeddings }));
+
+    const provider = new FakeProvider([textResponse('Hi')]);
+    const orchestrator = makeOrchestrator(provider);
+    const fake = createFakeMessage({
+      content: `<@${BOT_ID}> what is the weather`,
+      botUserId: BOT_ID,
+      mentionedUserIds: [BOT_ID],
+    });
+
+    await orchestrator.handleMention(fake.message);
+
+    const query = lastQuery(embeddings);
+    expect(query).toBe('what is the weather');
+    expect(query).not.toContain(BOT_ID);
+    expect(query).not.toContain('@');
+  });
+
+  it("strips an unknown mention (no live data, no identity) — today's behavior", async () => {
+    const embeddings = new FakeEmbeddingProvider();
+    setMemoryStoreForTesting(new MemoryStore(':memory:', { embeddings }));
+
+    const provider = new FakeProvider([textResponse('Hi')]);
+    const orchestrator = makeOrchestrator(provider);
+    const fake = createFakeMessage({
+      content: `what about <@${STRANGER_ID}> then`,
+      botUserId: BOT_ID,
+      mentionedUserIds: [STRANGER_ID],
+    });
+
+    await orchestrator.handleMention(fake.message);
+
+    const query = lastQuery(embeddings);
+    expect(query).toBe('what about then');
+    expect(query).not.toContain('<@');
+    expect(query).not.toContain(STRANGER_ID);
+  });
+
+  it('injects subject memories for a mentioned user', async () => {
+    // High relevance gate so the contextual-search leg returns nothing and the dedicated mentioned
+    // pull is the only thing that can surface Wheezer's memory.
+    const store = new MemoryStore(':memory:', { embeddings: new FakeEmbeddingProvider(), relevanceThreshold: 0.99 });
+    await store.save({ category: 'fact', subject: 'Wheezer', content: 'plays valorant every night' });
+    setMemoryStoreForTesting(store);
+
+    const provider = new FakeProvider([textResponse('Hi')]);
+    const orchestrator = makeOrchestrator(provider);
+    const fake = createFakeMessage({
+      content: `whats up with <@${WHEEZER_ID}>`,
+      botUserId: BOT_ID,
+      mentionedUsers: [{ id: WHEEZER_ID, displayName: 'Wheezer' }],
+    });
+
+    await orchestrator.handleMention(fake.message);
+
+    const promptText = developerPromptText(provider);
+    expect(promptText).toContain('What you know about others mentioned in this message:');
+    expect(promptText).toContain('- Wheezer: plays valorant every night');
+  });
+
+  it('excludes the bot and the speaker from the mentioned-subjects pull', async () => {
+    const store = new MemoryStore(':memory:');
+    await store.save({ category: 'fact', subject: 'Frigidaire', content: 'is a fridge' });
+    await store.save({ category: 'fact', subject: 'Speaker', content: 'speaker fact' });
+    setMemoryStoreForTesting(store);
+
+    const provider = new FakeProvider([textResponse('Hi')]);
+    const orchestrator = makeOrchestrator(provider);
+    const fake = createFakeMessage({
+      content: `hey <@${BOT_ID}> and <@${SPEAKER_ID}>`,
+      botUserId: BOT_ID,
+      authorId: SPEAKER_ID,
+      authorDisplayName: 'Speaker',
+      mentionedUsers: [
+        { id: BOT_ID, displayName: 'Frigidaire' },
+        { id: SPEAKER_ID, displayName: 'Speaker' },
+      ],
+    });
+
+    await orchestrator.handleMention(fake.message);
+
+    expect(developerPromptText(provider)).not.toContain('others mentioned in this message');
+  });
+
+  it('resolves mention tokens in the model-visible user message text', async () => {
+    setMemoryStoreForTesting(new MemoryStore(':memory:'));
+
+    const provider = new FakeProvider([textResponse('Hi')]);
+    const orchestrator = makeOrchestrator(provider);
+    const fake = createFakeMessage({
+      content: `yo <@${WHEEZER_ID}> you up`,
+      botUserId: BOT_ID,
+      mentionedUsers: [{ id: WHEEZER_ID, displayName: 'Wheezer' }],
+    });
+
+    await orchestrator.handleMention(fake.message);
+
+    const userText = lastUserText(provider);
+    expect(userText).toContain('@Wheezer');
+    expect(userText).not.toContain('<@');
   });
 });

--- a/src/ai/agent.ts
+++ b/src/ai/agent.ts
@@ -5,7 +5,7 @@ import { splitMessage } from '../utils';
 import { ConversationStore } from './conversationStore';
 import { writeErrorCapture } from './debugCapture';
 import { logFailure } from './failureLogger';
-import type { EmojiRow, Identity, Memory } from './memory/memoryStore';
+import type { EmojiRow, Identity, Memory, MemoryStore } from './memory/memoryStore';
 import { getProviderForChannel } from './providerRegistry';
 import { getMemoryStore, toolDefinitions } from './tools';
 import type {
@@ -21,6 +21,28 @@ import { formatRelativeAge, formatTimestampET } from './utils';
 const CONVERSATION_TIMEOUT = Number(process.env.CONVERSATION_TIMEOUT_MS) || 15 * 60 * 1000; // 15 minutes
 const MAX_TOOL_ROUNDS = Number(process.env.MAX_TOOL_ROUNDS) || 10;
 const MAX_TOOL_INVOCATIONS = Number(process.env.MAX_TOOL_INVOCATIONS) || 50;
+
+// `<@123>` / `<@!123>` user mentions (the legacy `!` is the old nickname form). Role (`<@&>`) and
+// channel (`<#>`) mentions are deliberately not matched.
+const USER_MENTION_REGEX = /<@!?(\d+)>/g;
+// Bound prompt growth: at most this many distinct mentioned users get a subject-memory pull.
+const MAX_MENTIONED_SUBJECTS = 3;
+
+/**
+ * Rewrites user-mention tokens in `text`: the bot's own ping is removed (it's the trigger, noise in
+ * every message), other ids become `@DisplayName`, and unresolved ids are dropped — matching the
+ * pre-existing strip behavior when nothing resolves. Collapses spaces a removed token leaves behind.
+ */
+function resolveMentionTokens(text: string, botUserId: string, resolve: (id: string) => string | undefined): string {
+  return text
+    .replace(USER_MENTION_REGEX, (_match, id: string) => {
+      if (id === botUserId) return '';
+      const name = resolve(id);
+      return name ? `@${name}` : '';
+    })
+    .replace(/ {2,}/g, ' ')
+    .trim();
+}
 
 export type AgentOrchestratorOptions = {
   resolveProvider?: (channelId: string) => AiProvider | undefined;
@@ -266,7 +288,7 @@ export class AgentOrchestrator {
   private async buildInitialHistory(message: Message, provider: AiProvider): Promise<ConversationEntry[]> {
     const botName = message.client.user.displayName;
     const currentUser = message.member?.displayName || message.author.username;
-    const basePrompt = await this.buildDeveloperPrompt(botName, currentUser, provider, message.content);
+    const basePrompt = await this.buildDeveloperPrompt(botName, currentUser, provider, message);
     const entries: ConversationEntry[] = [
       {
         kind: 'message',
@@ -317,7 +339,7 @@ export class AgentOrchestrator {
     botName: string,
     currentUserDisplayName: string,
     _provider: AiProvider,
-    currentMessageContent: string,
+    message: Message,
   ): Promise<string> {
     const now = new Date();
     const tz = 'America/New_York';
@@ -337,6 +359,7 @@ export class AgentOrchestrator {
     let personalityMemories: Memory[] = [];
     let userSpecificMemories: Memory[] = [];
     let contextualMemories: Memory[] = [];
+    let mentionedMemories: Memory[] = [];
     let identities: Identity[] = [];
     let usableEmojis: EmojiRow[] = [];
 
@@ -362,20 +385,25 @@ export class AgentOrchestrator {
       // Cap user-specific memories to 5
       userSpecificMemories = store.getBySubject(currentUserDisplayName, 5);
 
-      // Contextual relevance search based on current message
-      const searchText = currentMessageContent.replace(/<@!?\d+>/g, '').trim();
+      // Contextual relevance search based on current message. Resolve @-mentions to display names
+      // (rather than stripping them) so the person being asked about survives into the search query.
+      const searchText = resolveMentionTokens(message.content, message.client.user.id, (id) =>
+        this.resolveMentionDisplayName(id, message, store),
+      );
+      const existingIds = new Set([...personalityMemories.map((m) => m.id), ...userSpecificMemories.map((m) => m.id)]);
       if (searchText.length >= 3) {
         try {
           const ftsResults = await store.search(searchText, 10);
-          const existingIds = new Set([
-            ...personalityMemories.map((m) => m.id),
-            ...userSpecificMemories.map((m) => m.id),
-          ]);
           contextualMemories = ftsResults.filter((m) => !existingIds.has(m.id));
         } catch (error) {
           logger.warn('Failed to fetch contextual memories:', error);
         }
       }
+
+      // Pull subject-keyed memories for other people @-mentioned in the message, so "what's up with
+      // @Wheezer" surfaces what we know about Wheezer even when nothing keyword-matches.
+      for (const mem of contextualMemories) existingIds.add(mem.id);
+      mentionedMemories = this.collectMentionedSubjectMemories(message, store, existingIds);
     } catch (error) {
       logger.warn('Failed to fetch memories for prompt:', error);
     }
@@ -391,6 +419,11 @@ export class AgentOrchestrator {
     const userSection =
       userSpecificMemories.length > 0
         ? `\nWhat you know about the person talking to you right now (${currentUserDisplayName}):\n${userSpecificMemories.map((m) => `- ${m.content} (${formatRelativeAge(m.updated_at)})`).join('\n')}\n`
+        : '';
+
+    const mentionedSection =
+      mentionedMemories.length > 0
+        ? `\nWhat you know about others mentioned in this message:\n${mentionedMemories.map((m) => `- ${m.subject}: ${m.content} (${formatRelativeAge(m.updated_at)})`).join('\n')}\n`
         : '';
 
     const contextualSection =
@@ -415,7 +448,7 @@ How you behave:
 - Never say "I'm just an AI" or "as a language model" — you're ${botName}, period.
 
 You can search the web natively. Use it SPARINGLY — only when you genuinely need current, real-time information you couldn't possibly know (live scores, recent news, release dates, etc). Don't search for things you already know. Don't follow links people share.
-${identitiesSection}${emojisSection}${personalitySection}${userSection}${contextualSection}
+${identitiesSection}${emojisSection}${personalitySection}${userSection}${mentionedSection}${contextualSection}
 These memories are background knowledge — things you know from hanging out in this server. Do NOT force references to inside jokes, show off what you know, or try to reference multiple memories in one response. Let things come up naturally, the way you'd reference a friend's hobby only when it's actually relevant to the conversation. If nothing from your memories is relevant to what's being discussed, just don't mention them. Each memory is tagged with how long ago it was last confirmed; treat months-old current-state claims — what someone "still" does, owns, or plays — as possibly outdated, so hedge or ask instead of asserting them as current fact.
 
 MEMORY: You have a long-term memory system. Use the remember_fact tool when something genuinely important comes up — real names, jobs, major life events, strong preferences, or things someone would expect you to remember next time. Do NOT save every little thing; skip small talk, throwaway opinions, and mundane details. Think of what you'd actually remember about a friend after a night out — the big stuff, not every sentence. If someone corrects a fact you know, save the updated version.
@@ -427,6 +460,64 @@ The last user message in the conversation is why you're being pinged. Read it fi
 - Gap awareness: look at the timestamps. If the prior messages are hours older than the current ping AND the current message introduces something new, treat the older stuff as stale scenery, not live subject matter.
 
 The current time is ${currentTimeEt.replace(' ', 'T')} (ISO 8601, America/New_York; apply EST/EDT automatically).`;
+  }
+
+  /**
+   * Resolves a mentioned user's id to a display name: live guild member data first (most accurate
+   * current nickname), then the resolved User, then the identities table by discord_user_id — whose
+   * `display_name` is the exact key memories are stored under. Returns undefined when nothing knows
+   * the id, so callers fall back to stripping (today's behavior).
+   */
+  private resolveMentionDisplayName(id: string, message: Message, store: MemoryStore | undefined): string | undefined {
+    const memberName = message.mentions.members?.get(id)?.displayName;
+    if (memberName) return memberName;
+    const userName = message.mentions.users.get(id)?.displayName;
+    if (userName) return userName;
+    return store?.getIdentityById(id)?.display_name;
+  }
+
+  /**
+   * Collects subject-keyed memories for the (non-bot, non-speaker) users @-mentioned in the message.
+   * Caps the number of distinct users and dedups against memories already injected via `alreadyInjected`.
+   */
+  private collectMentionedSubjectMemories(
+    message: Message,
+    store: MemoryStore,
+    alreadyInjected: Set<number>,
+  ): Memory[] {
+    const botUserId = message.client.user.id;
+    const speakerId = message.author.id;
+    const seenIds = new Set<string>();
+    const collected: Memory[] = [];
+    let resolvedUsers = 0;
+
+    for (const match of message.content.matchAll(USER_MENTION_REGEX)) {
+      const id = match[1];
+      if (id === botUserId || id === speakerId || seenIds.has(id)) continue;
+      seenIds.add(id);
+
+      const displayName = this.resolveMentionDisplayName(id, message, store);
+      if (!displayName) continue;
+
+      for (const mem of store.getBySubject(displayName, 3)) {
+        if (alreadyInjected.has(mem.id)) continue;
+        alreadyInjected.add(mem.id);
+        collected.push(mem);
+      }
+
+      resolvedUsers++;
+      if (resolvedUsers >= MAX_MENTIONED_SUBJECTS) break;
+    }
+
+    return collected;
+  }
+
+  private safeStore(): MemoryStore | undefined {
+    try {
+      return getMemoryStore();
+    } catch {
+      return undefined;
+    }
   }
 
   private formatIdentitiesSection(identities: Identity[]): string {
@@ -468,7 +559,13 @@ ${lines.join('\n')}
   private buildUserContentParts(msg: Message): NormalizedContentPart[] {
     const parts: NormalizedContentPart[] = [];
     const authorLabel = msg.member?.displayName || msg.author.username;
-    const trimmed = msg.content?.trim();
+    // Resolve @-mentions to readable names (same logic as the search query) so the model reads
+    // "@Wheezer" rather than a raw numeric id. Only touches the store when a mention is present.
+    const rawContent = msg.content ?? '';
+    const mentionStore = rawContent.includes('<@') ? this.safeStore() : undefined;
+    const trimmed = resolveMentionTokens(rawContent, msg.client.user.id, (id) =>
+      this.resolveMentionDisplayName(id, msg, mentionStore),
+    );
     const ts = formatTimestampET(msg.createdAt);
     // Webhook reposts use the webhook's author ID (not the original user's), so omit the ID in that case.
     const idSuffix = !msg.webhookId && !msg.author.bot ? ` (id:${msg.author.id})` : '';

--- a/src/test-support/fakeDiscord.ts
+++ b/src/test-support/fakeDiscord.ts
@@ -32,6 +32,10 @@ export type FakeMessageOptions = {
   }>;
   stickers?: Array<{ id: string; name: string; format: number }>;
   mentionedUserIds?: string[];
+  // Mentioned users with resolved display data, mirroring discord.js `message.mentions.users` /
+  // `.members`. `member: false` puts the user in `.users` only (not a guild member). When omitted,
+  // `mentionedUserIds` still populates `.users` with bare entries (no display name) for has() checks.
+  mentionedUsers?: Array<{ id: string; displayName?: string; username?: string; member?: boolean }>;
   referencedMessageId?: string | null;
   memberIsNull?: boolean;
   historyMessages?: Message[];
@@ -88,8 +92,15 @@ export function createFakeMessage(opts: FakeMessageOptions = {}): FakeMessage {
   }
 
   const mentionUsers = new Collection<string, unknown>();
+  const mentionMembers = new Collection<string, unknown>();
   for (const id of mentionedUserIds) {
-    mentionUsers.set(id, {});
+    mentionUsers.set(id, { id });
+  }
+  for (const m of opts.mentionedUsers ?? []) {
+    mentionUsers.set(m.id, { id: m.id, displayName: m.displayName, username: m.username });
+    if (m.member !== false) {
+      mentionMembers.set(m.id, { id: m.id, displayName: m.displayName });
+    }
   }
 
   const embeds = (opts.embeds ?? []).map((embed) => ({
@@ -153,7 +164,7 @@ export function createFakeMessage(opts: FakeMessageOptions = {}): FakeMessage {
     attachments,
     embeds,
     stickers,
-    mentions: { users: mentionUsers },
+    mentions: { users: mentionUsers, members: mentionMembers },
     reference: referencedMessageId ? { messageId: referencedMessageId } : null,
     client: {
       user: { id: botUserId, displayName: botDisplayName },


### PR DESCRIPTION
When a bot mention also @-mentioned another user, the memory-search query stripped every `<@id>` token, so the person being asked about ("what's up with @Wheezer") vanished from the query and none of their memories were retrieved.

Now mention tokens are resolved to display names (live guild member data -> identities table -> strip if unknown) before building the search query, so the subject survives into the embedding. The bot's own trigger mention is still removed (noise in every query). The same resolution is applied to the model-visible message text so the model reads "@Wheezer" rather than a raw numeric id, in the current message and in seeded history.

Additionally, for up to MAX_MENTIONED_SUBJECTS distinct mentioned users (excluding the bot and the speaker, who has their own bucket), pull their subject-keyed memories via getBySubject and inject them in a dedicated "others mentioned in this message" prompt section, deduped against memories already injected.

Extends fakeDiscord with resolved mention display data (mentions.users / .members). Adds 7 orchestration tests: query resolution, identities fallback, bot-mention stripping, unknown-id stripping, subject-pull injection, bot/speaker exclusion, and model-visible text resolution.