### PR TITLE
Fix process import: namespace copy loses EventEmitter prototype methods

### DIFF
--- a/src/ai/agent.ts
+++ b/src/ai/agent.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import process from 'node:process';
 import { type Message, StickerFormatType } from 'discord.js';
 import { logger } from '../logger';
 import { splitMessage } from '../utils';

--- a/src/ai/emojiCaptioner.ts
+++ b/src/ai/emojiCaptioner.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import process from 'node:process';
 import OpenAI from 'openai';
 import { logger } from '../logger';
 

--- a/src/ai/memory/embeddingProvider.ts
+++ b/src/ai/memory/embeddingProvider.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import process from 'node:process';
 import OpenAI from 'openai';
 import { normalize } from './vectorMath';
 

--- a/src/ai/personalityLearner.ts
+++ b/src/ai/personalityLearner.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import process from 'node:process';
 import { ChannelType, type Client, type Collection, type Message, type TextChannel } from 'discord.js';
 import OpenAI from 'openai';
 import type { ChatCompletionContentPart } from 'openai/resources/chat/completions';

--- a/src/ai/providers/openRouterProvider.ts
+++ b/src/ai/providers/openRouterProvider.ts
@@ -1,5 +1,5 @@
 import * as crypto from 'node:crypto';
-import * as process from 'node:process';
+import process from 'node:process';
 import { AttachmentBuilder, type Message } from 'discord.js';
 import OpenAI from 'openai';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';

--- a/src/ai/tools/localImageGenerator.ts
+++ b/src/ai/tools/localImageGenerator.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import process from 'node:process';
 import { AttachmentBuilder, type Message } from 'discord.js';
 import OpenAI from 'openai';
 import { logger } from '../../logger';

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as process from 'node:process';
+import process from 'node:process';
 import { Client, GatewayIntentBits } from 'discord.js';
 import * as dotenv from 'dotenv';
 import { getConversationPersistence } from './ai/conversationPersistence';

--- a/src/events/emojiReady.ts
+++ b/src/events/emojiReady.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import process from 'node:process';
 import { type Client, Events, type GuildEmoji } from 'discord.js';
 import { syncEmoji } from '../ai/emojiSync';
 import { getMemoryStore } from '../ai/tools';


### PR DESCRIPTION
import * as process from 'node:process' compiles to an __importStar copy that only carries own enumerable properties — process.env works, but process.on/.once (EventEmitter prototype) are missing, crashing app.ts at boot on the new SIGTERM handler. Default import binds the real object. Applied to all 8 files using the pattern so no future prototype-method use can trip on it.